### PR TITLE
Fix for Unparenthesized `a ? b : c ? d : e` is deprecated

### DIFF
--- a/src/ResultTypes/GetResult.php
+++ b/src/ResultTypes/GetResult.php
@@ -23,7 +23,14 @@ class GetResult extends OperationResult
         }
         else {
             $this->data = $apiResponse->body;
-            $this->errorMessage = !empty($this->errorMessage) ? $this->errorMessage : isset($apiResponse->body->error) ? $apiResponse->body->error : '';
+            if(empty($this->errorMessage)) {
+                if(isset($apiResponse->body->error)) {
+                    $this->errorMessage = $apiResponse->body->error;
+                } else {
+                    $this->errorMessage = '';
+                }
+            }
+            
             if ($apiResponse->code >= 200 && $apiResponse->code < 300) {
                 $this->isSuccess = (strlen($this->errorMessage) == 0);
             }


### PR DESCRIPTION
With PHP 7.4, line 26 is causing an error message. This logic should solve it.

`Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` {"exception":"[object] (ErrorException(code: 0): Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` at /home/forge/miraclewatt.com/vendor/maropost/api/src/ResultTypes/GetResult.php:26)`